### PR TITLE
fix：修复引用原库报错问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# OSX
+#
+.DS_Store
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+
+# Vscode / Eclipse
+.settings/
+.project
+.classpath
+.vscode/
+
+# node.js
+#
+node_modules/
+
+# Logs
+*.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+.github
+example
+.DS_Store
+*.log
+.*
+*.tgz
+*.spec.js
+*.snap
+fixtures

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "printWidth": 80,
+  "singleQuote": true,
+  "trailingComma": "es5",
+}

--- a/README.md
+++ b/README.md
@@ -8,12 +8,7 @@
 
 [英文 / English](https://gitee.com/react-native-oh-library/usage-docs/blob/master/zh-en/react-native-vector-drawable.md)
 
-## Codegen
-
-该库已接入 codegen，具体请查阅文档。
-
-The library has been integrated with codegen. Please refer to the documentation for details.
 
 ## 请悉知 / Acknowledgements
 
-本项目基于 MIT License ([react-native-vector-drawable](https://github.com/klarna-incubator/react-native-vector-drawable/blob/master/LICENSE)) ，请自由地享受和参与开源。
+本项目基于 [The Apache License (Apache)](https://github.com/klarna-incubator/react-native-vector-drawable/blob/master/LICENSE) ，请自由地享受和参与开源。

--- a/android/.npmignore
+++ b/android/.npmignore
@@ -1,0 +1,10 @@
+*.iml
+.DS_Store
+.gradle/
+.idea/
+.npmignore
+build/
+gradle/
+gradlew
+gradlew.bat
+local.properties

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,56 @@
+buildscript {
+    ext.safeExtGet = {prop, fallback ->
+        rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    }
+    repositories {
+        google()
+    gradlePluginPortal()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:7.2.0")
+    }
+}
+
+def isNewArchitectureEnabled() {
+        return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
+apply plugin: 'com.android.library'
+
+if (isNewArchitectureEnabled()) {
+    apply plugin: 'com.facebook.react'
+}
+
+android {
+    namespace "com.klarna.vectordrawable"
+    compileSdkVersion safeExtGet('compileSdkVersion', 31)
+
+    defaultConfig {
+        minSdkVersion safeExtGet('minSdkVersion', 21)
+        targetSdkVersion safeExtGet('targetSdkVersion', 31)
+        buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString())
+    }
+
+    sourceSets {
+        main {
+            if (isNewArchitectureEnabled()) {
+                java.srcDirs += ['src/newarch']
+            } else {
+                java.srcDirs += ['src/oldarch']
+            }
+        }
+    }
+}
+
+repositories {
+    maven {
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$projectDir/../node_modules/react-native/android"
+    }
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation 'com.facebook.react:react-native:+'
+}

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  >
+</manifest>

--- a/android/src/main/java/com/klarna/vectordrawable/VectorDrawableManagerImpl.java
+++ b/android/src/main/java/com/klarna/vectordrawable/VectorDrawableManagerImpl.java
@@ -1,0 +1,81 @@
+package com.klarna.vectordrawable;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.PorterDuff.Mode;
+import android.graphics.drawable.Drawable;
+import androidx.core.content.ContextCompat;
+import android.widget.ImageView;
+import android.widget.ImageView.ScaleType;
+
+import com.facebook.react.common.JavascriptException;
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
+import com.facebook.react.uimanager.ThemedReactContext;
+
+import javax.annotation.Nullable;
+
+public class VectorDrawableManagerImpl {
+
+    public static final String NAME = "RNVectorDrawable";
+
+    public static ImageView createViewInstance(ThemedReactContext context) {
+        ImageView view = new ImageView(context);
+        view.setCropToPadding(true);
+        view.setScaleType(toScaleType(null));
+        return view;
+    }
+
+    public static void setResourceName(ImageView view, @Nullable String resourceName) {
+        Drawable draw = createVectorDrawable(view.getContext(), resourceName);
+        view.setImageDrawable(draw);
+    }
+
+    public static void setTintColor(ImageView view, @Nullable Integer tintColor) {
+        if (tintColor == null) {
+            view.clearColorFilter();
+        } else {
+            view.setColorFilter(tintColor, Mode.SRC_IN);
+        }
+    }
+
+    public static void setResizeMode(ImageView view, @Nullable String resizeMode) {
+        view.setScaleType(toScaleType(resizeMode));
+    }
+
+    private static final String RESIZE_MODE_CONTAIN = "contain";
+    private static final String RESIZE_MODE_COVER = "cover";
+    private static final String RESIZE_MODE_STRETCH = "stretch";
+    private static final String RESIZE_MODE_CENTER = "center";
+    private static ScaleType toScaleType(@Nullable String resizeModeValue) {
+        if (resizeModeValue == null || RESIZE_MODE_COVER.equals(resizeModeValue)) {
+            return ScaleType.CENTER_CROP;
+        }
+        if (RESIZE_MODE_CONTAIN.equals(resizeModeValue)) {
+            return ScaleType.FIT_CENTER;
+        }
+        if (RESIZE_MODE_STRETCH.equals(resizeModeValue)) {
+            return ScaleType.FIT_XY;
+        }
+        if (RESIZE_MODE_CENTER.equals(resizeModeValue)) {
+            return ScaleType.CENTER_INSIDE;
+        }
+
+        throw new JSApplicationIllegalArgumentException("Invalid resize mode: '" + resizeModeValue + "'");
+    }
+
+    private static Drawable createVectorDrawable(Context context, String resourceName) throws JavascriptException {
+        int resourceIdent;
+        String packageName = context.getPackageName();
+        resourceIdent = context.getResources()
+                               .getIdentifier(resourceName, "drawable", packageName);
+        if (resourceIdent == 0) {
+            resourceIdent = context.getResources()
+                                   .getIdentifier(resourceName, "drawable-hdpi", packageName);
+        }
+        if (resourceIdent == 0) {
+            throw new JavascriptException("Unable to find resource " + resourceName + " in " + packageName);
+        }
+
+        return ContextCompat.getDrawable(context, resourceIdent);
+    }
+}

--- a/android/src/main/java/com/klarna/vectordrawable/VectorDrawablePackage.java
+++ b/android/src/main/java/com/klarna/vectordrawable/VectorDrawablePackage.java
@@ -1,0 +1,26 @@
+package com.klarna.vectordrawable;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class VectorDrawablePackage implements ReactPackage {
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        List<ViewManager> viewManagers = new ArrayList<>();
+        viewManagers.add(new VectorDrawableManager(reactContext));
+        return viewManagers;
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+}

--- a/android/src/newarch/java/com/klarna/vectordrawable/VectorDrawableManager.java
+++ b/android/src/newarch/java/com/klarna/vectordrawable/VectorDrawableManager.java
@@ -1,0 +1,61 @@
+package com.klarna.vectordrawable;
+
+import android.widget.ImageView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.module.annotations.ReactModule;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewProps;
+import com.facebook.react.uimanager.ViewManagerDelegate;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.viewmanagers.RNVectorDrawableManagerDelegate;
+import com.facebook.react.viewmanagers.RNVectorDrawableManagerInterface;
+
+@ReactModule(name = VectorDrawableManagerImpl.NAME)
+public class VectorDrawableManager extends SimpleViewManager<ImageView>
+        implements RNVectorDrawableManagerInterface<ImageView> {
+    private final ViewManagerDelegate<ImageView> mDelegate;
+
+    public VectorDrawableManager(ReactApplicationContext context) {
+        mDelegate = new RNVectorDrawableManagerDelegate<>(this);
+    }
+
+    @Nullable
+    @Override
+    protected ViewManagerDelegate<ImageView> getDelegate() {
+        return mDelegate;
+    }
+
+    @Nullable
+    @Override
+    public String getName() {
+        return VectorDrawableManagerImpl.NAME;
+    }
+
+    @NonNull
+    @Override
+    protected ImageView createViewInstance(@NonNull ThemedReactContext context) {
+        return VectorDrawableManagerImpl.createViewInstance(context);
+    }
+
+    @Override
+    @ReactProp(name = "resourceName")
+    public void setResourceName(ImageView view, @Nullable String resourceName) {
+        VectorDrawableManagerImpl.setResourceName(view, resourceName);
+    }
+
+    @Override
+    @ReactProp(name = ViewProps.RESIZE_MODE)
+    public void setResizeMode(ImageView view, @Nullable String resizeMode) {
+        VectorDrawableManagerImpl.setResizeMode(view, resizeMode);
+    }
+
+    @Override
+    @ReactProp(name = "tintColor", customType = "Color")
+    public void setTintColor(ImageView view, @Nullable Integer tintColor) {
+        VectorDrawableManagerImpl.setTintColor(view, tintColor);
+    }
+}

--- a/android/src/oldarch/java/com/klarna/vectordrawable/VectorDrawableManager.java
+++ b/android/src/oldarch/java/com/klarna/vectordrawable/VectorDrawableManager.java
@@ -1,0 +1,45 @@
+package com.klarna.vectordrawable;
+
+import android.widget.ImageView;
+import androidx.annotation.NonNull;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewProps;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import javax.annotation.Nullable;
+
+public class VectorDrawableManager extends SimpleViewManager<ImageView> {
+    ReactApplicationContext mCallerContext;
+
+    public VectorDrawableManager(ReactApplicationContext reactContext) {
+        mCallerContext = reactContext;
+    }
+
+    @NonNull
+    @Override
+    public String getName() {
+        return VectorDrawableManagerImpl.NAME;
+    }
+
+    @NonNull
+    @Override
+    protected ImageView createViewInstance(ThemedReactContext context) {
+        return VectorDrawableManagerImpl.createViewInstance(context);
+    }
+
+    @ReactProp(name="resourceName")
+    public void setResourceName(ImageView view, @Nullable String resourceName) {
+        VectorDrawableManagerImpl.setResourceName(view, resourceName);
+    }
+
+    @ReactProp(name = ViewProps.RESIZE_MODE)
+    public void setResizeMode(ImageView view, @Nullable String resizeMode) {
+        VectorDrawableManagerImpl.setResizeMode(view, resizeMode);
+    }
+
+    @ReactProp(name = "tintColor", customType = "Color")
+    public void setTintColor(ImageView view, @Nullable Integer tintColor) {
+        VectorDrawableManagerImpl.setTintColor(view, tintColor);
+    }
+}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,0 @@
-import * as IosOrAndroidVectorDrawable from '@klarna/react-native-vector-drawable';
-import { Platform } from 'react-native';
-const isIosOrAndroid = Platform.OS === 'android' || Platform.OS === 'ios';
-const VectorDrawable = isIosOrAndroid ? IosOrAndroidVectorDrawable.default : View
-export default VectorDrawable

--- a/package.json
+++ b/package.json
@@ -2,19 +2,15 @@
   "name": "@react-native-oh-tpl/react-native-vector-drawable",
   "version": "0.5.1-0.0.1",
   "description": "Android vector drawables in React Native",
-  "main": "index.js",
-  "scripts": {
+  "main": "src",
+  "types": "src/index.d.ts",
+   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": {
-    "type":"git",
-    "url":"git://github.com/react-native-oh-library/react-native-vector-drawable.git"
-  },
-  "homepage": "https://github.com/klarna-incubator/react-native-vector-drawable",
-  "bugs": {
-    "url": "https://github.com/klarna-incubator/react-native-vector-drawable/issues"
-  },
   "license": "Apache-2.0",
+  "harmony": {
+    "alias": "react-native-vector-drawable"
+  },
   "keywords": [
     "react-native",
     "react",
@@ -25,12 +21,6 @@
     "image"
   ],
   "author": "Joel Arvidsson",
-  "dependencies":{
-    "@klarna/react-native-vector-drawable":"0.5.1"
-  },
-  "harmony": {
-    "alias": "react-native-vector-drawable"
-  },
   "devDependencies": {
     "@types/react-native": "^0.67.8",
     "prettier": "^2.2.1"

--- a/src/RNVectorDrawableNativeComponent.android.ts
+++ b/src/RNVectorDrawableNativeComponent.android.ts
@@ -1,0 +1,25 @@
+import { ViewProps, ColorValue, HostComponent } from 'react-native';
+
+// @ts-ignore
+import { WithDefault } from 'react-native/Libraries/Types/CodegenTypes';
+// @ts-ignore
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+export type VectorDrawableResizeMode =
+  | 'cover'
+  | 'contain'
+  | 'stretch'
+  | 'center';
+
+export interface VectorDrawableProps extends ViewProps {
+  /**
+   * The name of the vector drawable resource.
+   */
+  resourceName: string;
+  resizeMode?: WithDefault<VectorDrawableResizeMode, 'contain'>;
+  tintColor?: ColorValue;
+}
+
+export default codegenNativeComponent<VectorDrawableProps>(
+  'RNVectorDrawable'
+) as HostComponent<VectorDrawableProps>;

--- a/src/index.android.js
+++ b/src/index.android.js
@@ -1,0 +1,9 @@
+import { requireNativeComponent } from 'react-native';
+
+const isFabricEnabled = global.nativeFabricUIManager != null;
+
+const RNVectorDrawable = isFabricEnabled
+  ? require('./RNVectorDrawableNativeComponent').default
+  : requireNativeComponent('RNVectorDrawable');
+
+export default RNVectorDrawable;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import {
+  ColorValue,
+  StyleProp,
+  ViewProps,
+  FlexStyle,
+  TransformsStyle,
+} from 'react-native';
+
+export type VectorDrawableResizeMode =
+  | 'cover'
+  | 'contain'
+  | 'stretch'
+  | 'center';
+
+export interface VectorDrawableStyle extends FlexStyle, TransformsStyle {
+  resizeMode?: VectorDrawableResizeMode;
+  tintColor?: ColorValue;
+  opacity?: number;
+}
+
+export interface VectorDrawableProps extends ViewProps {
+  /**
+   * The name of the vector drawable resource.
+   */
+  resourceName: string;
+  /**
+   * Style
+   */
+  style?: StyleProp<VectorDrawableStyle>;
+}
+
+declare const VectorDrawable: React.FunctionComponent<VectorDrawableProps>;
+
+export default VectorDrawable;

--- a/src/index.harmony.js
+++ b/src/index.harmony.js
@@ -1,0 +1,1 @@
+export { View as default } from 'react-native';

--- a/src/index.ios.js
+++ b/src/index.ios.js
@@ -1,0 +1,1 @@
+export { View as default } from 'react-native';


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Close #3 

- 在原库src目录下增加index.harmony.js文件，解决了原库在HarmonyOs引用报错问题

# Test Plan

修改之后，在RN28环境能够正常引入不报错

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [X] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

